### PR TITLE
WIP Remove payload from PATCH /users endpoint

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -380,7 +380,7 @@ func (c *UserController) getKeycloakProfileInformation(ctx context.Context, toke
 }
 
 func (c *UserController) updateWITUser(ctx *app.UpdateUserContext, request *goa.RequestData, identityID string) error {
-	updateUserPayload := &app.UpdateUsersPayload{
+	updateUserPayload := &app.UpdateUserPayload{
 		Data: &app.UpdateUserData{
 			Attributes: &app.UpdateIdentityDataAttributes{
 				Bio:                   ctx.Payload.Data.Attributes.Bio,

--- a/controller/users.go
+++ b/controller/users.go
@@ -368,29 +368,6 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 	return proxy.RouteHTTPToPath(ctx, "http://localhost:8089", client.UpdateUserPath())
 }
 
-func (c *UsersController) updateWITUser(ctx *app.UpdateUsersContext, request *goa.RequestData, identityID string) error {
-	updateUserPayload := &app.UpdateUsersPayload{
-		Data: &app.UpdateUserData{
-			Attributes: &app.UpdateIdentityDataAttributes{
-				Bio:                   ctx.Payload.Data.Attributes.Bio,
-				Company:               ctx.Payload.Data.Attributes.Company,
-				ContextInformation:    ctx.Payload.Data.Attributes.ContextInformation,
-				Email:                 ctx.Payload.Data.Attributes.Email,
-				FullName:              ctx.Payload.Data.Attributes.FullName,
-				ImageURL:              ctx.Payload.Data.Attributes.ImageURL,
-				RegistrationCompleted: ctx.Payload.Data.Attributes.RegistrationCompleted,
-				URL:      ctx.Payload.Data.Attributes.URL,
-				Username: ctx.Payload.Data.Attributes.Username,
-			},
-			Type: ctx.Payload.Data.Type,
-		},
-	}
-	witURL, err := c.config.GetWITURL(ctx.RequestData)
-	if err != nil {
-		return err
-	}
-	return c.RemoteWITService.UpdateWITUser(ctx, request, updateUserPayload, witURL, identityID)
-}
 
 func isEmailValid(email string) bool {
 	// TODO: Add regex to verify email format, later

--- a/design/account.go
+++ b/design/account.go
@@ -171,7 +171,6 @@ var _ = a.Resource("users", func() {
 			a.PATCH(""),
 		)
 		a.Description("update the authenticated user")
-		a.Payload(updateUser)
 		a.Response(d.OK, func() {
 			a.Media(user)
 		})

--- a/login/service.go
+++ b/login/service.go
@@ -748,7 +748,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateIdentityInDB(ctx context.Co
 }
 
 func (keycloak *KeycloakOAuthProvider) updateWITUser(ctx context.Context, request *goa.RequestData, identity *account.Identity, witURL string, identityID string) error {
-	updateUserPayload := &app.UpdateUsersPayload{
+	updateUserPayload := &app.UpdateUserPayload{
 		Data: &app.UpdateUserData{
 			Attributes: &app.UpdateIdentityDataAttributes{
 				Bio:      &identity.User.Bio,

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -19,14 +19,14 @@ import (
 
 // RemoteWITService specifies the behaviour of a remote WIT caller
 type RemoteWITService interface {
-	UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUsersPayload, witURL string, identityID string) error
+	UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUserPayload, witURL string, identityID string) error
 	CreateWITUser(ctx context.Context, req *goa.RequestData, identity *account.Identity, witURL string, identityID string) error
 }
 
 type RemoteWITServiceCaller struct{}
 
 // UpdateWITUser updates user in WIT
-func (r *RemoteWITServiceCaller) UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUsersPayload, witURL string, identityID string) error {
+func (r *RemoteWITServiceCaller) UpdateWITUser(ctx context.Context, req *goa.RequestData, updatePayload *app.UpdateUserPayload, witURL string, identityID string) error {
 
 	// Using the UpdateUserPayload because it also describes which attribtues are being updated and which are not.
 	updateUserPayload := &witservice.UpdateUserAsServiceAccountUsersPayload{


### PR DESCRIPTION
The `PATCH` request to /users endpoint will be routed to `PATCH` on /user endpoint.
`PATCH` request on /user endpoint requires a `UpdateUserPayload` and so the payload can be removed from `PATCH` on /users


This works similar to how wit proxies `update` action on `/users` to `updateUserAsServiceAccount` action on `/users`.

To do - Fix failing tests